### PR TITLE
[Pref] #33 Page 성능 최적화

### DIFF
--- a/app/api/posts/posts-api.ts
+++ b/app/api/posts/posts-api.ts
@@ -58,7 +58,7 @@ export const getPostsByCategoryAndPage = async (
   const to = from + PAGE_SIZE - 1;
 
   let query = client
-    .from('posts')
+    .from('posts_with_excerpt')
     .select('*')
     .order('created_at', { ascending: false })
     .range(from, to);
@@ -76,11 +76,24 @@ export const getPostsByCategoryAndPage = async (
   return data;
 };
 
-export const getPostTotalPagesByCategoryAndPage = async (
+export const getPopularPostsWithExcerpt = async (client: SupabaseClient<Database>) => {
+  const { data, error } = await client
+    .from('posts_with_excerpt')
+    .select('*')
+    .order('view_count', { ascending: false })
+    .limit(5);
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
+export const getPostTotalPagesByCategory = async (
   client: SupabaseClient<Database>,
   categoryId: number,
 ) => {
-  let query = client.from('posts').select('*', { count: 'exact', head: true });
+  let query = client.from('posts_with_excerpt').select('*', { count: 'exact', head: true });
 
   if (categoryId !== -1) {
     query = query.eq('tag_id', categoryId);
@@ -107,12 +120,8 @@ export const getPopularPosts = async (client: SupabaseClient<Database>) => {
   return data;
 };
 
-// 클라이언트 사이드 필터링용: VIEW를 사용하여 excerpt만 가져옴 (content 전체 대신)
-export const getAllPostsForFiltering = async (client: SupabaseClient<Database>) => {
-  const { data, error } = await client
-    .from('posts_with_excerpt')
-    .select('*')
-    .order('created_at', { ascending: false });
+export const getAllPostsForBuildingCategoriesTree = async (client: SupabaseClient<Database>) => {
+  const { data, error } = await client.from('posts').select('post_id, title, category_id');
   if (error) {
     throw new Error(error.message);
   }

--- a/app/lib/buildCategoriesTree.ts
+++ b/app/lib/buildCategoriesTree.ts
@@ -26,6 +26,7 @@ export const buildCategoriesTree = (
   // B. 현재 카테고리(parentId)에 바로 속해 있는 포스트(파일)들을 구성
   const postNodes: FolderItemProps[] = posts
     .filter((post) => post.category_id === parentId)
+    .sort((a, b) => a.title.localeCompare(b.title)) // 제목 순서대로 정렬
     .map((post) => ({
       name: post.title,
       isFolder: false, // 파일이므로 false

--- a/app/lib/buildCategoriesTree.ts
+++ b/app/lib/buildCategoriesTree.ts
@@ -1,10 +1,10 @@
 import type { FolderItemProps } from '~/types/folderItemProps';
 import type { getCategories } from '~/api/categories/categories-api';
-import type { getAllPostsForFiltering } from '~/api/posts/posts-api';
+import type { getAllPostsForBuildingCategoriesTree } from '~/api/posts/posts-api';
 
 export const buildCategoriesTree = (
   categories: Awaited<ReturnType<typeof getCategories>>,
-  posts: Awaited<ReturnType<typeof getAllPostsForFiltering>>,
+  posts: Awaited<ReturnType<typeof getAllPostsForBuildingCategoriesTree>>,
   parentId: number | null,
 ): FolderItemProps[] => {
   // A. 현재 레벨의 카테고리(폴더)들을 먼저 구성

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -80,8 +80,11 @@ function transformViewCountByTagToChartData(
 }
 
 export const loader = async () => {
-  const posts = await getAllPostsForOverview(client);
-  const viewCountByTag = await getViewCountByTag(client);
+  const [posts, viewCountByTag, categoriesGroupedByViewCount] = await Promise.all([
+    getAllPostsForOverview(client),
+    getViewCountByTag(client),
+    getCategoriesGroupedByViewCount(client),
+  ]);
 
   const totalViews = posts.reduce((acc, post) => acc + post.view_count, 0);
   const averageReadTime = posts.reduce((acc, post) => acc + post.read_time, 0) / posts.length;
@@ -89,7 +92,6 @@ export const loader = async () => {
   const averageReadTimeMinutes = Math.floor(averageReadTime % 60);
   const totalPosts = posts.length;
 
-  const categoriesGroupedByViewCount = await getCategoriesGroupedByViewCount(client);
   const totalCategories = categoriesGroupedByViewCount.length;
   const mostViewedCategories = categoriesGroupedByViewCount
     .sort((a, b) => b.total_view_count - a.total_view_count)

--- a/app/pages/popularPosts.tsx
+++ b/app/pages/popularPosts.tsx
@@ -1,21 +1,23 @@
 import { NavLink, useOutletContext } from 'react-router';
 import PopularPostCard from '~/components/ui/popularPostCard';
-import { useMemo } from 'react';
 import { markdownToText } from '~/lib/markdown-to-text';
-import type { getAllPostsForFiltering } from '~/api/posts/posts-api';
-import type { getCategories } from '~/api/categories/categories-api';
+import { getPopularPostsWithExcerpt } from '~/api/posts/posts-api';
+import type { getTopLevelCategories } from '~/api/categories/categories-api';
 import type { CategoryName } from '~/lib/category-config';
+import { client } from '~/supa-client';
+import type { Route } from './+types/popularPosts';
 
-export default function PopularPosts() {
-  const { posts, categories } = useOutletContext<{
-    posts: Awaited<ReturnType<typeof getAllPostsForFiltering>>;
-    categories: Awaited<ReturnType<typeof getCategories>>;
+export const loader = async () => {
+  const popularPosts = await getPopularPostsWithExcerpt(client);
+  return { popularPosts };
+};
+
+export default function PopularPosts({ loaderData }: Route.ComponentProps) {
+  const { topLevelCategories } = useOutletContext<{
+    topLevelCategories: Awaited<ReturnType<typeof getTopLevelCategories>>;
   }>();
-  const { popularPosts } = useMemo(() => {
-    const sortedPosts = [...posts].sort((a, b) => (b.view_count || 0) - (a.view_count || 0));
-    const popularPosts = sortedPosts.slice(0, 5);
-    return { popularPosts };
-  }, [posts]);
+  const { popularPosts } = loaderData;
+
   return (
     <div className='flex flex-col gap-8 max-w-[1400px] md:ml-20'>
       <div className='flex flex-col gap-4'>
@@ -29,8 +31,8 @@ export default function PopularPosts() {
             title={post.title}
             description={markdownToText(post.excerpt || '', 300)}
             category={
-              (categories.find((c) => c.category_id === post.tag_id)?.name as CategoryName) ||
-              'null'
+              (topLevelCategories?.find((c) => c.category_id === post.tag_id)
+                ?.name as CategoryName) || 'null'
             }
             date={new Date(post.created_at)}
             link={`/post/${post.post_id}`}

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -3,7 +3,6 @@ import type { Route } from './+types/posts';
 import { cva } from 'class-variance-authority';
 import PostCard from '~/components/ui/postCard';
 import PostPagination from '~/components/layout/postPagination';
-import { useMemo } from 'react';
 import { markdownToText } from '~/lib/markdown-to-text';
 import { getPostsByCategoryAndPage, getPostTotalPagesByCategory } from '~/api/posts/posts-api';
 import type { getTopLevelCategories } from '~/api/categories/categories-api';
@@ -37,23 +36,30 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     throw new Response('Invalid params', { status: 400 });
   }
 
-  const totalPages = await getPostTotalPagesByCategory(client, data.category);
-
   // 쿼리 파라미터에서 page 읽기 및 검증
   const url = new URL(request.url);
   const pageParam = url.searchParams.get('page');
   const pageNum = pageParam ? parseInt(pageParam, 10) : 1;
 
-  if (pageNum < 1 || pageNum > totalPages || isNaN(pageNum)) {
-    return redirect(`/posts/all?page=1`);
-  }
-  // 이상한 값(음수, 0, NaN 등)이면 1로 처리
-  const page = pageNum;
+  // 병렬 실행
+  const [totalPages, posts] = await Promise.all([
+    getPostTotalPagesByCategory(client, data.category),
+    getPostsByCategoryAndPage(client, data.category, pageNum),
+  ]);
 
-  const posts = await getPostsByCategoryAndPage(client, data.category, page);
+  // 페이지 범위를 벗어난 경우에만 리다이렉트
+  if (pageNum < 1 || (totalPages > 0 && pageNum > totalPages)) {
+    return redirect(`/posts/${params.category || 'all'}?page=1`);
+  }
+
+  const postsWithProcessedExcerpt = posts.map((post) => ({
+    ...post,
+    processedExcerpt: markdownToText(post.excerpt || '', 300),
+  }));
+
   return {
     totalPages,
-    posts,
+    postsWithProcessedExcerpt,
   };
 };
 
@@ -70,19 +76,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
   const { topLevelCategories } = useOutletContext<{
     topLevelCategories: Awaited<ReturnType<typeof getTopLevelCategories>>;
   }>();
-  const { posts, totalPages } = loaderData;
-
-  const { posts: filteredPosts } = useMemo(() => {
-    // markdownToText를 한 번만 계산
-    const postsWithProcessedExcerpt = posts.map((post) => ({
-      ...post,
-      processedExcerpt: markdownToText(post.excerpt || '', 300),
-    }));
-
-    return {
-      posts: postsWithProcessedExcerpt,
-    };
-  }, [posts]);
+  const { postsWithProcessedExcerpt, totalPages } = loaderData;
 
   return (
     <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] md:ml-20'>
@@ -113,7 +107,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
           ))}
         </div>
         <div className='flex flex-col gap-4'>
-          {filteredPosts.map((post) => {
+          {postsWithProcessedExcerpt.map((post) => {
             const postWithExcerpt = post as typeof post & { processedExcerpt?: string };
             return (
               <PostCard

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -1,14 +1,14 @@
-import { NavLink, useOutletContext } from 'react-router';
+import { NavLink, redirect, useOutletContext } from 'react-router';
 import type { Route } from './+types/posts';
 import { cva } from 'class-variance-authority';
 import PostCard from '~/components/ui/postCard';
 import PostPagination from '~/components/layout/postPagination';
 import { useMemo } from 'react';
 import { markdownToText } from '~/lib/markdown-to-text';
-import type { getAllPostsForFiltering } from '~/api/posts/posts-api';
-import type { getCategories } from '~/api/categories/categories-api';
+import { getPostsByCategoryAndPage, getPostTotalPagesByCategory } from '~/api/posts/posts-api';
+import type { getTopLevelCategories } from '~/api/categories/categories-api';
 import { z } from 'zod';
-const PAGE_SIZE = 5; // 한 페이지에 보여줄 글 개수
+import { client } from '~/supa-client';
 
 const paramsSchema = z.object({
   category: z
@@ -37,16 +37,23 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     throw new Response('Invalid params', { status: 400 });
   }
 
+  const totalPages = await getPostTotalPagesByCategory(client, data.category);
+
   // 쿼리 파라미터에서 page 읽기 및 검증
   const url = new URL(request.url);
   const pageParam = url.searchParams.get('page');
   const pageNum = pageParam ? parseInt(pageParam, 10) : 1;
-  // 이상한 값(음수, 0, NaN 등)이면 1로 처리
-  const page = pageNum > 0 && !isNaN(pageNum) ? pageNum : 1;
 
+  if (pageNum < 1 || pageNum > totalPages || isNaN(pageNum)) {
+    return redirect(`/posts/all?page=1`);
+  }
+  // 이상한 값(음수, 0, NaN 등)이면 1로 처리
+  const page = pageNum;
+
+  const posts = await getPostsByCategoryAndPage(client, data.category, page);
   return {
-    categoryId: data.category,
-    page,
+    totalPages,
+    posts,
   };
 };
 
@@ -60,33 +67,22 @@ const navLinkVariants = cva('rounded-full border px-4 py-1', {
 });
 
 export default function Posts({ loaderData }: Route.ComponentProps) {
-  const { categoryId, page } = loaderData;
-  const { posts, categories } = useOutletContext<{
-    posts: Awaited<ReturnType<typeof getAllPostsForFiltering>>;
-    categories: Awaited<ReturnType<typeof getCategories>>;
+  const { topLevelCategories } = useOutletContext<{
+    topLevelCategories: Awaited<ReturnType<typeof getTopLevelCategories>>;
   }>();
+  const { posts, totalPages } = loaderData;
 
-  const { posts: filteredPosts, totalPages } = useMemo(() => {
-    let result = posts;
-    if (categoryId !== -1) {
-      result = posts.filter((p) => p.tag_id === categoryId);
-    }
-
-    const totalPages = Math.ceil(result.length / PAGE_SIZE);
-
-    const paginatedPosts = result.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-
+  const { posts: filteredPosts } = useMemo(() => {
     // markdownToText를 한 번만 계산
-    const postsWithProcessedExcerpt = paginatedPosts.map((post) => ({
+    const postsWithProcessedExcerpt = posts.map((post) => ({
       ...post,
       processedExcerpt: markdownToText(post.excerpt || '', 300),
     }));
 
     return {
       posts: postsWithProcessedExcerpt,
-      totalPages,
     };
-  }, [posts, categoryId, page]);
+  }, [posts]);
 
   return (
     <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] md:ml-20'>
@@ -105,7 +101,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
           >
             View All
           </NavLink>
-          {categories?.map((category) => (
+          {topLevelCategories?.map((category) => (
             <NavLink
               key={category.category_id}
               to={`/posts/${category.category_id}`}
@@ -125,7 +121,8 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
                 title={post.title}
                 description={postWithExcerpt.processedExcerpt || post.excerpt || ''}
                 categoryName={
-                  (categories?.find((c) => c.category_id === post.tag_id)?.name as string) || 'null'
+                  (topLevelCategories?.find((c) => c.category_id === post.tag_id)
+                    ?.name as string) || 'null'
                 }
                 date={new Date(post.created_at)}
                 link={`/post/${post.post_id}`}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,7 +18,7 @@ import LeftSidebar from './components/layout/leftSideBar';
 import { Toaster } from 'sonner';
 import { client } from './supa-client';
 import { getCategories } from './api/categories/categories-api';
-import { getAllPostsForFiltering } from './api/posts/posts-api';
+import { getAllPostsForBuildingCategoriesTree } from './api/posts/posts-api';
 import { buildCategoriesTree } from './lib/buildCategoriesTree';
 import type { FolderItemProps } from './types/folderItemProps';
 import { getEvents } from './api/events/events-api';
@@ -59,7 +59,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   const [categories, posts, events] = await Promise.all([
     getCategories(client),
-    getAllPostsForFiltering(client),
+    getAllPostsForBuildingCategoriesTree(client),
     getEvents(client),
   ]);
 
@@ -71,7 +71,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     categoriesTree,
     topLevelCategories,
     categories,
-    posts,
     events,
   };
 };
@@ -141,10 +140,8 @@ export default function App({ loaderData }: Route.ComponentProps) {
         />
         <Outlet
           context={{
-            categories: loaderData?.topLevelCategories,
+            topLevelCategories: loaderData?.topLevelCategories,
             allCategories: loaderData?.categories,
-            posts: loaderData?.posts,
-            categoriesTree: loaderData?.categoriesTree,
           }}
         />
       </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -50,6 +50,19 @@ export const links: Route.LinksFunction = () => [
   },
 ];
 
+export const shouldRevalidate = (
+  currentUrl: URL | undefined,
+  nextUrl: URL | undefined,
+  formMethod: string | undefined,
+  defaultShouldRevalidate: boolean,
+) => {
+  if (currentUrl?.pathname !== nextUrl?.pathname) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
+};
+
 export const loader = async ({ request }: Route.LoaderArgs) => {
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY || !process.env.DATABASE_URL) {
     throw new Error('Missing environment variables');

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -57,12 +57,14 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   const { getTheme } = await themeSessionResolver(request);
   const theme = getTheme();
 
-  const categories = await getCategories(client);
-  const topLevelCategories = categories.filter((c) => c.parent_id === null);
-  const posts = await getAllPostsForFiltering(client);
-  const categoriesTree = buildCategoriesTree(categories, posts, null);
+  const [categories, posts, events] = await Promise.all([
+    getCategories(client),
+    getAllPostsForFiltering(client),
+    getEvents(client),
+  ]);
 
-  const events = await getEvents(client);
+  const topLevelCategories = categories.filter((c) => c.parent_id === null);
+  const categoriesTree = buildCategoriesTree(categories, posts, null);
 
   return {
     theme,


### PR DESCRIPTION
## 📂 관련 이슈

- closes #33 

<br>

## 🔀 PR 개요

> Page 성능 최적화

<br>

## 📝 작업 내용

- root의 Data를 promize all로 호출 병렬화
- post api loader 위치 변경 및 각 Page에 필요한 Data만 불러오도록 수정
- 카테고리 Tree 정렬 기준 추가
- root에 shouldRevalidate 기능 추가
- posts loader 병렬 실행 및 markdownToText를 server 측에서 실행하도록 구현
- dashboard loader 병렬 실행

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
