### PR TITLE
[Feat] #35 Page Meta Data 추가

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import { CodeXmlIcon, Command, MoonIcon, Search, SunIcon } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { GithubIcon } from '~/assets';
 import {
   NavigationMenu,
@@ -24,7 +24,7 @@ export default function Header({
 }) {
   const [searchBarOpen, setSearchBarOpen] = useState(false);
   const [theme, setTheme] = useTheme();
-
+  const location = useLocation();
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
@@ -113,7 +113,14 @@ export default function Header({
                       </NavigationMenuContent>
                     </>
                   ) : (
-                    <Link className={navigationMenuTriggerStyle()} to={menu.to ?? '/'}>
+                    <Link
+                      className={cn(
+                        navigationMenuTriggerStyle(),
+                        location.pathname === menu.to &&
+                          'bg-accent text-accent-foreground font-medium',
+                      )}
+                      to={menu.to ?? '/'}
+                    >
                       {menu.title}
                     </Link>
                   )}

--- a/app/components/layout/postPagination.tsx
+++ b/app/components/layout/postPagination.tsx
@@ -71,7 +71,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
     } else {
       newSearchParams.set('page', pageNum.toString());
     }
-    setSearchParams(newSearchParams);
+    setSearchParams(newSearchParams, { preventScrollReset: true });
   };
 
   if (totalPages <= 1) {
@@ -89,6 +89,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
             <PaginationPrevious
               to={createPageUrl(page - 1)}
               onClick={(e) => handlePageClick(page - 1, e)}
+              prefetch='intent'
             />
           </PaginationItem>
         )}
@@ -123,6 +124,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
             <PaginationNext
               to={createPageUrl(page + 1)}
               onClick={(e) => handlePageClick(page + 1, e)}
+              prefetch='intent'
             />
           </PaginationItem>
         )}

--- a/app/pages/about.tsx
+++ b/app/pages/about.tsx
@@ -15,8 +15,15 @@ import { Button } from '~/components/ui/button';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import json from 'react-syntax-highlighter/dist/cjs/languages/prism/json';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import { Link } from 'react-router';
+import { Link, type MetaFunction } from 'react-router';
 import TechBadge from '~/components/ui/techBadge';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'About | Dongle' },
+    { name: 'description', content: 'About page of My portfolio' },
+  ];
+};
 
 SyntaxHighlighter.registerLanguage('json', json.default || json);
 

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -12,10 +12,17 @@ import DashboardCard from '~/components/ui/dashboardCard';
 import { client } from '~/supa-client';
 import { getAllPostsForOverview, getViewCountByTag } from '~/api/posts/posts-api';
 import type { Route } from './+types/dashboard';
-import { Link } from 'react-router';
+import { Link, type MetaFunction } from 'react-router';
 import { getCategoriesGroupedByViewCount } from '~/api/categories/categories-api';
 import { categoryColors } from '~/lib/category-config';
 import type { ChartConfig } from '~/components/ui/chart';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Dashboard | Dongle' },
+    { name: 'description', content: 'Dashboard page of Blog' },
+  ];
+};
 
 const chartConfig: ChartConfig = {
   algorithm: {

--- a/app/pages/popularPosts.tsx
+++ b/app/pages/popularPosts.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useOutletContext } from 'react-router';
+import { NavLink, useOutletContext, type MetaFunction } from 'react-router';
 import PopularPostCard from '~/components/ui/popularPostCard';
 import { markdownToText } from '~/lib/markdown-to-text';
 import { getPopularPostsWithExcerpt } from '~/api/posts/posts-api';
@@ -6,6 +6,13 @@ import type { getTopLevelCategories } from '~/api/categories/categories-api';
 import type { CategoryName } from '~/lib/category-config';
 import { client } from '~/supa-client';
 import type { Route } from './+types/popularPosts';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Popular Posts | Dongle' },
+    { name: 'description', content: 'Popular posts page of Blog with most read articles' },
+  ];
+};
 
 export const loader = async () => {
   const popularPosts = await getPopularPostsWithExcerpt(client);

--- a/app/pages/post.tsx
+++ b/app/pages/post.tsx
@@ -15,6 +15,13 @@ import { markdownToHtml } from '~/lib/markdown-to-html';
 import type { getCategories } from '~/api/categories/categories-api';
 import { z } from 'zod';
 
+export const meta: Route.MetaFunction = ({ loaderData }: Route.MetaArgs) => {
+  return [
+    { title: `${loaderData.post.title} | Dongle` },
+    { name: 'description', content: `Post page of Blog ${loaderData.post.title}` },
+  ];
+};
+
 const paramsSchema = z.object({
   id: z.coerce.number(),
 });

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -1,4 +1,4 @@
-import { NavLink, redirect, useOutletContext } from 'react-router';
+import { NavLink, redirect, useOutletContext, type MetaFunction } from 'react-router';
 import type { Route } from './+types/posts';
 import { cva } from 'class-variance-authority';
 import PostCard from '~/components/ui/postCard';
@@ -8,6 +8,13 @@ import { getPostsByCategoryAndPage, getPostTotalPagesByCategory } from '~/api/po
 import type { getTopLevelCategories } from '~/api/categories/categories-api';
 import { z } from 'zod';
 import { client } from '~/supa-client';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'All Posts | Dongle' },
+    { name: 'description', content: 'Posts page of Blog with all posts and categories' },
+  ];
+};
 
 const paramsSchema = z.object({
   category: z


### PR DESCRIPTION
## 📂 관련 이슈

- closes #35 

<br>

## 🔀 PR 개요

> Page meta Data 추가

<br>

## 📝 작업 내용

- Dashboard Page Meta Data 추가
- All Page Meta Data 추가
- Popular Posts Page Meta Data 추가
- About Page Meta Data 추가
- header menu 버튼이 현재 경로에 맞으면 하이라이트 되도록 구현
- Post Page Meta Data 추가
- All Posts Page에서 Page 이동 시 스크롤이 reset 되지 않도록 구현

<br>

## 📸 스크린샷
<img width="115" height="25" alt="image" src="https://github.com/user-attachments/assets/278bc561-12d5-416b-ae5f-23436267ece6" />
<img width="166" height="23" alt="image" src="https://github.com/user-attachments/assets/5af51693-49cf-4460-8850-feb65f2775fd" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
