### PR TITLE
[Feat] #37 404 Error Page 구현

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -132,7 +132,7 @@ export default function Header({
         <div className='flex items-center gap-2 mr-5'>
           <Button
             variant='outline'
-            className='hidden md:flex text-muted-foreground w-[200px] justify-start relative cursor-text'
+            className='text-muted-foreground w-[200px] justify-start relative cursor-text'
             onClick={() => setSearchBarOpen(true)}
           >
             <Search className='size-4 ' />

--- a/app/components/layout/leftSidebarLayout.tsx
+++ b/app/components/layout/leftSidebarLayout.tsx
@@ -1,0 +1,24 @@
+import { Outlet, useOutletContext } from 'react-router';
+import LeftSidebar from './leftSideBar';
+import type { FolderItemProps } from '~/types/folderItemProps';
+import type { Route } from '../../+types/root';
+
+export default function LeftSidebarLayout() {
+  const { loaderData } = useOutletContext<{
+    loaderData: Route.ComponentProps['loaderData'];
+  }>();
+  return (
+    <div className='mx-auto xl:mx-20 grid grid-cols-1 md:grid-cols-[280px_1fr] xl:grid-cols-[280px_1fr] gap-8 px-6 py-8'>
+      <LeftSidebar
+        categoriesTree={loaderData.categoriesTree as FolderItemProps[]}
+        events={loaderData.events}
+      />
+      <Outlet
+        context={{
+          topLevelCategories: loaderData?.topLevelCategories,
+          allCategories: loaderData?.categories,
+        }}
+      />
+    </div>
+  );
+}

--- a/app/pages/not-found.tsx
+++ b/app/pages/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>NotFound</div>;
+}

--- a/app/pages/not-found.tsx
+++ b/app/pages/not-found.tsx
@@ -16,7 +16,7 @@ import PopularPostCard from '~/components/ui/popularPostCard';
 
 export const meta: MetaFunction = () => {
   return [
-    { title: 'Not Found | Dongle' },
+    { title: '404 Not Found | Dongle' },
     { name: 'description', content: 'Not found page of Dongle' },
   ];
 };
@@ -47,7 +47,7 @@ export default function NotFound({ loaderData }: Route.ComponentProps) {
   };
 
   return (
-    <div className='flex flex-col items-center gap-8 px-8'>
+    <div className='flex flex-col items-center gap-8 px-8 max-w-[1400px] mx-auto'>
       <div className='relative mt-16'>
         <h1 className='text-[120px] md:text-[180px] font-black leading-none tracking-tighter text-transparent bg-clip-text bg-gradient-to-b from-primary/80 to-primary/10 select-none'>
           404

--- a/app/pages/not-found.tsx
+++ b/app/pages/not-found.tsx
@@ -1,6 +1,6 @@
 import { ArrowRightIcon, Search } from 'lucide-react';
 import { useState } from 'react';
-import { Link } from 'react-router';
+import { Link, type MetaFunction } from 'react-router';
 import { toast } from 'sonner';
 import { Toaster } from 'sonner';
 import Searchbar from '~/components/layout/searchbar';
@@ -13,6 +13,13 @@ import { client } from '~/supa-client';
 import type { CategoryName } from '~/lib/category-config';
 import { markdownToText } from '~/lib/markdown-to-text';
 import PopularPostCard from '~/components/ui/popularPostCard';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Not Found | Dongle' },
+    { name: 'description', content: 'Not found page of Dongle' },
+  ];
+};
 
 export const loader = async () => {
   const popularPosts = await getPopularPostsWithExcerpt(client);

--- a/app/pages/not-found.tsx
+++ b/app/pages/not-found.tsx
@@ -6,8 +6,26 @@ import { Toaster } from 'sonner';
 import Searchbar from '~/components/layout/searchbar';
 import { Button } from '~/components/ui/button';
 import { Separator } from '~/components/ui/separator';
+import type { Route } from './+types/not-found';
+import { getTopLevelCategories } from '~/api/categories/categories-api';
+import { getPopularPostsWithExcerpt } from '~/api/posts/posts-api';
+import { client } from '~/supa-client';
+import type { CategoryName } from '~/lib/category-config';
+import { markdownToText } from '~/lib/markdown-to-text';
+import PopularPostCard from '~/components/ui/popularPostCard';
 
-export default function NotFound() {
+export const loader = async () => {
+  const popularPosts = await getPopularPostsWithExcerpt(client);
+  const topLevelCategories = await getTopLevelCategories(client);
+  return { popularPosts, topLevelCategories };
+};
+
+export default function NotFound({ loaderData }: Route.ComponentProps) {
+  const { popularPosts, topLevelCategories } = (loaderData as unknown as {
+    popularPosts: Awaited<ReturnType<typeof getPopularPostsWithExcerpt>>;
+    topLevelCategories: Awaited<ReturnType<typeof getTopLevelCategories>>;
+  }) || { popularPosts: [], topLevelCategories: [] };
+
   const [searchBarOpen, setSearchBarOpen] = useState(false);
 
   const handleCopyEmail = async () => {
@@ -57,9 +75,9 @@ export default function NotFound() {
         </div>
       </div>
       <Separator />
-      <div className='w-full mt-4'>
+      <div className='w-full mt-4 flex flex-col gap-6'>
         <div className='flex flex-row gap-2 justify-between'>
-          <h2 className='text-xl md:text-2xl font-bold'>
+          <h2 className='text-base sm:text-xl md:text-2xl font-bold'>
             While you&apos;re here, check out these popular posts :
           </h2>
           <Link
@@ -69,6 +87,24 @@ export default function NotFound() {
             <span>View all posts</span>
             <ArrowRightIcon className='size-4' />
           </Link>
+        </div>
+        <div className='flex flex-col gap-4'>
+          {popularPosts.slice(0, 3).map((post, index) => (
+            <PopularPostCard
+              key={post.title}
+              title={post.title}
+              description={markdownToText(post.excerpt || '', 300)}
+              category={
+                (topLevelCategories?.find((c) => c.category_id === post.tag_id)
+                  ?.name as CategoryName) || 'null'
+              }
+              date={new Date(post.created_at)}
+              link={`/post/${post.post_id}`}
+              views={post.view_count}
+              readTime={post.read_time}
+              rank={index + 1}
+            />
+          ))}
         </div>
       </div>
       <Searchbar open={searchBarOpen} setOpen={setSearchBarOpen} />

--- a/app/pages/not-found.tsx
+++ b/app/pages/not-found.tsx
@@ -1,3 +1,78 @@
+import { ArrowRightIcon, Search } from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { toast } from 'sonner';
+import { Toaster } from 'sonner';
+import Searchbar from '~/components/layout/searchbar';
+import { Button } from '~/components/ui/button';
+import { Separator } from '~/components/ui/separator';
+
 export default function NotFound() {
-  return <div>NotFound</div>;
+  const [searchBarOpen, setSearchBarOpen] = useState(false);
+
+  const handleCopyEmail = async () => {
+    const email = 'shindong0321@gmail.com';
+    try {
+      await navigator.clipboard.writeText(email);
+      toast.success('이메일 주소가 복사되었습니다');
+    } catch {
+      // 클립보드 API가 실패하면 mailto 링크로 대체
+      window.location.href = `mailto:${email}`;
+    }
+  };
+
+  return (
+    <div className='flex flex-col items-center gap-8 px-8'>
+      <div className='relative mt-16'>
+        <h1 className='text-[120px] md:text-[180px] font-black leading-none tracking-tighter text-transparent bg-clip-text bg-gradient-to-b from-primary/80 to-primary/10 select-none'>
+          404
+        </h1>
+        <div className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full -z-10 blur-3xl opacity-20 bg-primary rounded-full'></div>
+      </div>
+      <div className='flex flex-col items-center gap-4 w-120'>
+        <h2 className='text-2xl md:text-3xl font-bold'>Oops! This Page is missing.</h2>
+        <p className='text-base md:text-lg text-muted-foreground text-center'>
+          The page you are looking for might have been removed, had its name changed, or is
+          temporarily unavailable. Maybe a search can help?
+        </p>
+      </div>
+      <div className='flex flex-col items-center gap-6 w-100 md:w-120'>
+        <Button
+          variant='outline'
+          className='w-full justify-start cursor-text text-muted-foreground p-6'
+          onClick={() => setSearchBarOpen(true)}
+        >
+          <Search className='size-4' />
+          <span className='text-sm font-medium'>Search for articles, projects...</span>
+        </Button>
+        <div className='flex flex-row gap-2 items-center'>
+          <Button asChild className='w-40 p-2'>
+            <Link to='/' className='text-sm font-medium'>
+              Back to Home
+            </Link>
+          </Button>
+          <Button variant='outline' className='w-40 p-2' onClick={() => handleCopyEmail()}>
+            Contact Support
+          </Button>
+        </div>
+      </div>
+      <Separator />
+      <div className='w-full mt-4'>
+        <div className='flex flex-row gap-2 justify-between'>
+          <h2 className='text-xl md:text-2xl font-bold'>
+            While you&apos;re here, check out these popular posts :
+          </h2>
+          <Link
+            to='/posts/all'
+            className='hidden md:flex flex-row gap-2 items-center text-sm font-medium text-primary'
+          >
+            <span>View all posts</span>
+            <ArrowRightIcon className='size-4' />
+          </Link>
+        </div>
+      </div>
+      <Searchbar open={searchBarOpen} setOpen={setSearchBarOpen} />
+      <Toaster position='top-center' />
+    </div>
+  );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -145,16 +145,16 @@ export function InnerLayout({ children }: { children: React.ReactNode }) {
 export default function App({ loaderData }: Route.ComponentProps) {
   return (
     <div>
-      <Header categories={loaderData?.topLevelCategories} />
+      <Header categories={loaderData.topLevelCategories} />
       <div className='mx-auto xl:mx-20 grid grid-cols-1 md:grid-cols-[280px_1fr] xl:grid-cols-[280px_1fr] gap-8 px-6 py-8'>
         <LeftSidebar
-          categoriesTree={loaderData?.categoriesTree as FolderItemProps[]}
-          events={loaderData?.events}
+          categoriesTree={loaderData.categoriesTree as FolderItemProps[]}
+          events={loaderData.events}
         />
         <Outlet
           context={{
-            topLevelCategories: loaderData?.topLevelCategories,
-            allCategories: loaderData?.categories,
+            topLevelCategories: loaderData.topLevelCategories,
+            allCategories: loaderData.categories,
           }}
         />
       </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,13 +14,11 @@ import './app.css';
 import Header from './components/layout/header';
 import { themeSessionResolver } from './lib/theme-session.server';
 import { ThemeProvider, useTheme } from 'remix-themes';
-import LeftSidebar from './components/layout/leftSideBar';
 import { Toaster } from 'sonner';
 import { client } from './supa-client';
 import { getCategories } from './api/categories/categories-api';
 import { getAllPostsForBuildingCategoriesTree } from './api/posts/posts-api';
 import { buildCategoriesTree } from './lib/buildCategoriesTree';
-import type { FolderItemProps } from './types/folderItemProps';
 import { getEvents } from './api/events/events-api';
 
 export const links: Route.LinksFunction = () => [
@@ -146,18 +144,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
   return (
     <div>
       <Header categories={loaderData.topLevelCategories} />
-      <div className='mx-auto xl:mx-20 grid grid-cols-1 md:grid-cols-[280px_1fr] xl:grid-cols-[280px_1fr] gap-8 px-6 py-8'>
-        <LeftSidebar
-          categoriesTree={loaderData.categoriesTree as FolderItemProps[]}
-          events={loaderData.events}
-        />
-        <Outlet
-          context={{
-            topLevelCategories: loaderData.topLevelCategories,
-            allCategories: loaderData.categories,
-          }}
-        />
-      </div>
+      <Outlet context={{ loaderData }} />
     </div>
   );
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,12 +1,14 @@
-import { type RouteConfig, index, prefix, route } from '@react-router/dev/routes';
+import { type RouteConfig, index, layout, prefix, route } from '@react-router/dev/routes';
 
 export default [
-  index('pages/index.tsx'),
-  ...prefix('posts', [route('/:category', 'pages/posts.tsx')]),
-  route('/popular', 'pages/popularPosts.tsx'),
-  route('/post/:id', 'pages/post.tsx'),
-  route('/about', 'pages/about.tsx'),
-  route('/dashboard', 'pages/dashboard.tsx'),
+  layout('components/layout/leftSidebarLayout.tsx', [
+    index('pages/index.tsx'),
+    ...prefix('posts', [route('/:category', 'pages/posts.tsx')]),
+    route('/popular', 'pages/popularPosts.tsx'),
+    route('/post/:id', 'pages/post.tsx'),
+    route('/about', 'pages/about.tsx'),
+    route('/dashboard', 'pages/dashboard.tsx'),
+  ]),
   // prettier-ignore
   ...prefix('api', [
     ...prefix('settings', [

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,4 +13,5 @@ export default [
       route('/theme', 'api/settings/set-theme.tsx'),
     ]),
   ]),
+  route('*', 'pages/not-found.tsx'),
 ] satisfies RouteConfig;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #37 

<br>

## 🔀 PR 개요

> 404 Error Page 구현

<br>

## 📝 작업 내용

- Splat Route 경로 설정
- Left SideBar Layout 분리
- 404 Page Style 구현
- 404 Page에 Popular Posts DB 연결
- 404 Page Meta Data 추가

<br>

## 📸 스크린샷
<img width="1447" height="1132" alt="image" src="https://github.com/user-attachments/assets/e528fff9-9e73-4ec7-831c-aab7ba07ce62" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
