### PR TITLE
[Feat] #55 세구 기능 추가

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -150,4 +150,47 @@
   .markdown-content ul li::marker {
     color: var(--color-gray-500);
   }
+
+  /* KaTeX 수식 반응형 스타일 */
+  /* 인라인 수식 */
+  .katex:not(.katex-display) {
+    max-width: 100% !important;
+    overflow-wrap: break-word !important;
+    word-break: break-word !important;
+    font-size: 0.85em !important;
+    display: inline-block;
+  }
+
+  @media (min-width: 640px) {
+    .katex:not(.katex-display) {
+      font-size: 1em !important;
+    }
+  }
+
+  /* 블록 수식 wrapper */
+  .katex-display-wrapper {
+    overflow-x: auto !important;
+    max-width: 100% !important;
+    margin: 1rem 0;
+  }
+
+  /* 블록 수식 */
+  .katex-display {
+    max-width: 100% !important;
+    font-size: 0.75em !important;
+    margin: 0 !important;
+  }
+
+  @media (min-width: 640px) {
+    .katex-display {
+      font-size: 1em !important;
+    }
+  }
+
+  /* KaTeX 내부 모든 요소에 반응형 적용 */
+  .katex *,
+  .katex-display * {
+    font-size: inherit !important;
+    max-width: 100% !important;
+  }
 }

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -80,12 +80,12 @@ export default function Header({
 
   return (
     <div className='sticky top-0 z-50 w-full border-b border-border-dark bg-background backdrop-blur'>
-      <div className='h-16 flex justify-between items-center pl-10 md:pl-20'>
+      <div className='h-16 flex justify-between items-center pl-5 md:pl-20'>
         <div className='flex items-center gap-4'>
           <div className='flex items-center gap-2'>
-            <CodeXmlIcon className='size-6' />
-            <Link to='/' className='text-2xl font-bold'>
-              Dongle
+            <Link to='/' className='flex flex-row items-center gap-2'>
+              <CodeXmlIcon className='size-6' />
+              <span className='text-2xl font-bold hidden md:block'>Dongle</span>
             </Link>
           </div>
           <NavigationMenu className='hidden md:block'>

--- a/app/components/layout/markdownHtmlRender.tsx
+++ b/app/components/layout/markdownHtmlRender.tsx
@@ -13,61 +13,61 @@ export default function MarkdownHtmlRender({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // 코드 블록에 복사 버튼 추가 함수
+  const addCopyButtons = () => {
+    if (!containerRef.current) return;
+
+    const preElements = containerRef.current.querySelectorAll('pre:not(.has-copy-button)');
+    preElements.forEach((preElement) => {
+      const codeElement = preElement.querySelector('code');
+      if (!codeElement) return;
+
+      const code = codeElement.textContent || '';
+
+      // 복사 버튼 추가
+      const copyButton = document.createElement('button');
+      copyButton.className =
+        'absolute top-2 right-2 z-5 p-2 hover:bg-accent rounded-md transition-colors bg-background/90 border border-border shadow-sm';
+      copyButton.setAttribute('type', 'button');
+      copyButton.setAttribute('aria-label', '코드 복사');
+      copyButton.innerHTML =
+        '<svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>';
+      copyButton.onclick = (e) => {
+        e.stopPropagation();
+        navigator.clipboard.writeText(code);
+        toast.success('코드가 복사되었습니다.');
+      };
+
+      // pre 요소에 relative 클래스가 없으면 추가
+      if (!preElement.classList.contains('relative')) {
+        preElement.classList.add('relative');
+      }
+
+      // pre 요소에 overflow 처리 추가 (텍스트가 넘치지 않도록)
+      (preElement as HTMLElement).style.whiteSpace = 'pre-wrap';
+      (preElement as HTMLElement).style.wordBreak = 'break-word';
+      (preElement as HTMLElement).style.overflowWrap = 'break-word';
+      (preElement as HTMLElement).style.maxWidth = '100%';
+
+      // code 요소에도 동일한 스타일 적용
+      if (codeElement) {
+        (codeElement as HTMLElement).style.whiteSpace = 'pre-wrap';
+        (codeElement as HTMLElement).style.wordBreak = 'break-word';
+        (codeElement as HTMLElement).style.overflowWrap = 'break-word';
+        (codeElement as HTMLElement).style.display = 'block';
+        (codeElement as HTMLElement).style.maxWidth = '100%';
+      }
+
+      preElement.appendChild(copyButton);
+      preElement.classList.add('has-copy-button');
+    });
+  };
+
   useEffect(() => {
     // 마운트 상태 추적
     let isMounted = true;
 
     if (!containerRef.current) return;
-
-    // 코드 블록에 복사 버튼 추가 함수
-    const addCopyButtons = () => {
-      if (!isMounted || !containerRef.current) return;
-
-      const preElements = containerRef.current.querySelectorAll('pre:not(.has-copy-button)');
-      preElements.forEach((preElement) => {
-        const codeElement = preElement.querySelector('code');
-        if (!codeElement) return;
-
-        const code = codeElement.textContent || '';
-
-        // 복사 버튼 추가
-        const copyButton = document.createElement('button');
-        copyButton.className =
-          'absolute top-2 right-2 z-5 p-2 hover:bg-accent rounded-md transition-colors bg-background/90 border border-border shadow-sm';
-        copyButton.setAttribute('type', 'button');
-        copyButton.setAttribute('aria-label', '코드 복사');
-        copyButton.innerHTML =
-          '<svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>';
-        copyButton.onclick = (e) => {
-          e.stopPropagation();
-          navigator.clipboard.writeText(code);
-          toast.success('코드가 복사되었습니다.');
-        };
-
-        // pre 요소에 relative 클래스가 없으면 추가
-        if (!preElement.classList.contains('relative')) {
-          preElement.classList.add('relative');
-        }
-
-        // pre 요소에 overflow 처리 추가 (텍스트가 넘치지 않도록)
-        (preElement as HTMLElement).style.whiteSpace = 'pre-wrap';
-        (preElement as HTMLElement).style.wordBreak = 'break-word';
-        (preElement as HTMLElement).style.overflowWrap = 'break-word';
-        (preElement as HTMLElement).style.maxWidth = '100%';
-
-        // code 요소에도 동일한 스타일 적용
-        if (codeElement) {
-          (codeElement as HTMLElement).style.whiteSpace = 'pre-wrap';
-          (codeElement as HTMLElement).style.wordBreak = 'break-word';
-          (codeElement as HTMLElement).style.overflowWrap = 'break-word';
-          (codeElement as HTMLElement).style.display = 'block';
-          (codeElement as HTMLElement).style.maxWidth = '100%';
-        }
-
-        preElement.appendChild(copyButton);
-        preElement.classList.add('has-copy-button');
-      });
-    };
 
     // DOM이 준비될 때까지 대기
     const processElements = () => {
@@ -79,23 +79,23 @@ export default function MarkdownHtmlRender({
       // 헤더 스타일 설정 매핑
       const headerStyles: Record<string, { className: string; hasSeparator?: boolean }> = {
         H1: {
-          className: 'text-3xl scroll-mt-24 font-extrabold tracking-tight my-5',
+          className: 'text-2xl md:text-3xl scroll-mt-24 font-extrabold tracking-tight my-5',
           hasSeparator: true,
         },
         H2: {
-          className: 'text-2xl scroll-mt-20 font-bold mb-2 mt-12',
+          className: 'text-xl md:text-2xl scroll-mt-20 font-bold mb-2 mt-12',
           hasSeparator: true,
         },
         H3: {
-          className: 'text-xl scroll-mt-20 font-semibold mb-2 mt-8',
+          className: 'text-lg md:text-xl scroll-mt-20 font-semibold mb-2 mt-8',
           hasSeparator: false,
         },
         H4: {
-          className: 'text-lg scroll-mt-20 font-medium mt-4',
+          className: 'text-base md:text-lg scroll-mt-20 font-medium mt-4',
           hasSeparator: false,
         },
         H5: {
-          className: 'text-base scroll-mt-20 font-semibold mb-4 mt-8',
+          className: 'text-sm md:text-base scroll-mt-20 font-semibold mb-4 mt-8',
           hasSeparator: false,
         },
       };
@@ -135,7 +135,8 @@ export default function MarkdownHtmlRender({
       const pElements = containerRef.current.querySelectorAll('p');
       pElements.forEach((p) => {
         if (!p.classList.contains('styled')) {
-          p.className = 'whitespace-pre-wrap break-words overflow-wrap-anywhere';
+          p.className =
+            'text-sm md:text-base whitespace-pre-wrap break-words overflow-wrap-anywhere';
           p.classList.add('styled');
         }
       });
@@ -144,7 +145,7 @@ export default function MarkdownHtmlRender({
       const ulElements = containerRef.current.querySelectorAll('ul');
       ulElements.forEach((ul) => {
         if (!ul.classList.contains('styled')) {
-          ul.className = 'list-disc ml-6 mb-2';
+          ul.className = 'text-sm md:text-base list-disc ml-6 mb-2';
           ul.classList.add('styled');
         }
       });
@@ -152,7 +153,7 @@ export default function MarkdownHtmlRender({
       const olElements = containerRef.current.querySelectorAll('ol');
       olElements.forEach((ol) => {
         if (!ol.classList.contains('styled')) {
-          ol.className = 'list-decimal ml-6 mb-2';
+          ol.className = 'text-sm md:text-base list-decimal ml-6 mb-2';
           ol.classList.add('styled');
         }
       });
@@ -160,7 +161,7 @@ export default function MarkdownHtmlRender({
       const liElements = containerRef.current.querySelectorAll('li');
       liElements.forEach((li) => {
         if (!li.classList.contains('styled')) {
-          li.className = 'mb-3 last:mb-0 leading-relaxed';
+          li.className = 'text-sm md:text-base mb-3 last:mb-0 leading-relaxed';
           li.classList.add('styled');
         }
 
@@ -199,7 +200,7 @@ export default function MarkdownHtmlRender({
       inlineCodeElements.forEach((code) => {
         if (!code.classList.contains('styled')) {
           code.className =
-            'text-sm font-mono text-code-content-color bg-code-background p-1 rounded-md break-words whitespace-pre-wrap';
+            'text-xs md:text-sm font-mono text-code-content-color bg-code-background p-1 rounded-md break-words whitespace-pre-wrap';
           code.classList.add('styled');
         }
       });
@@ -208,7 +209,8 @@ export default function MarkdownHtmlRender({
       const aElements = containerRef.current.querySelectorAll('a');
       aElements.forEach((a) => {
         if (!a.classList.contains('styled')) {
-          a.className = 'hover:text-primary/80 underline underline-offset-4 transition-colors';
+          a.className =
+            'text-sm md:text-base hover:text-primary/80 underline underline-offset-4 transition-colors';
           a.classList.add('styled');
         }
       });
@@ -217,7 +219,8 @@ export default function MarkdownHtmlRender({
       const quoteElements = containerRef.current.querySelectorAll('blockquote');
       quoteElements.forEach((quote) => {
         if (!quote.classList.contains('styled')) {
-          quote.className = 'border-l-4 border-primary/50 bg-muted/30 p-4 my-4 italic rounded-r-md';
+          quote.className =
+            'text-sm md:text-base border-l-4 border-primary/50 bg-muted/30 p-4 my-4 italic rounded-r-md';
           quote.classList.add('styled');
         }
       });
@@ -233,9 +236,9 @@ export default function MarkdownHtmlRender({
 
           // 테이블에 최소 너비 설정 (작은 화면에서 스크롤 가능하도록)
           (table as HTMLElement).style.tableLayout = 'auto';
-          (table as HTMLElement).style.minWidth = '800px'; // 최소 너비 설정
           (table as HTMLElement).style.width = 'auto';
-          table.className = 'border-collapse border border-border rounded-lg';
+          table.className =
+            'border-collapse border border-border rounded-lg text-sm md:text-base sm:min-w-[800px]';
           table.classList.add('styled');
 
           // 부모 노드에 wrapper 삽입하고 테이블을 wrapper 안으로 이동
@@ -273,8 +276,7 @@ export default function MarkdownHtmlRender({
           const row = (td as HTMLElement).parentElement;
           const rowIndex = Array.from(row?.parentElement?.children || []).indexOf(row as Element);
 
-          (td as HTMLElement).className =
-            'px-4 py-2 text-muted-foreground border-b border-zinc-800';
+          (td as HTMLElement).className = 'px-4 py-2 text-muted-foreground';
           td.classList.add('styled');
 
           // td 안의 이미지 크기 고정
@@ -307,6 +309,7 @@ export default function MarkdownHtmlRender({
       wikiLinks.forEach((link) => {
         if (!link.classList.contains('wiki-link-styled')) {
           link.classList.add(
+            'text-sm md:text-base',
             'hover:text-primary/80',
             'underline',
             'underline-offset-4',
@@ -348,18 +351,25 @@ export default function MarkdownHtmlRender({
         pdfContainer.appendChild(pdfIframe);
 
         // 3. 모바일에서 보기 힘들 수 있으므로 다운로드/새창 링크 추가 (선택 사항)
-        const downloadLink = document.createElement('a');
-        downloadLink.href = src;
-        downloadLink.target = '_blank';
-        downloadLink.className = 'block text-sm text-primary hover:underline mt-2 text-right';
-        downloadLink.innerText = '📄 새 창에서 PDF 열기 / 다운로드';
+        const downloadButtonWrapper = document.createElement('div');
+        downloadButtonWrapper.className = 'flex justify-end';
+
+        const downloadButton = document.createElement('button');
+        downloadButton.className =
+          'text-xs md:text-sm bg-transparent text-accent-foreground hover:cursor-pointer hover:underline';
+        downloadButton.innerText = '새 창에서 PDF 열기';
+        downloadButton.onclick = () => {
+          window.open(src, '_blank');
+        };
+
+        downloadButtonWrapper.appendChild(downloadButton);
 
         // 이미지를 컨테이너로 교체
         const parent = img.parentNode;
         if (parent) {
           parent.replaceChild(pdfContainer, img);
-          // 컨테이너 다음에 다운로드 링크 삽입
-          parent.insertBefore(downloadLink, pdfContainer.nextSibling);
+          // 컨테이너 이전에 다운로드 버튼 wrapper 삽입
+          parent.insertBefore(downloadButtonWrapper, pdfContainer);
         }
       });
 
@@ -590,6 +600,15 @@ export default function MarkdownHtmlRender({
   useEffect(() => {
     if (!containerRef.current) return;
     containerRef.current.innerHTML = htmlContent;
+
+    // HTML 업데이트 후 복사 버튼 추가
+    const timeoutId = setTimeout(() => {
+      addCopyButtons();
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, [htmlContent]);
 
   return <div ref={containerRef} className='markdown-content flex flex-col gap-4' />;

--- a/app/components/layout/postPagination.tsx
+++ b/app/components/layout/postPagination.tsx
@@ -85,7 +85,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
       <PaginationContent>
         {/* 이전 버튼 */}
         {page > 1 && (
-          <PaginationItem>
+          <PaginationItem className='hidden md:block'>
             <PaginationPrevious
               to={createPageUrl(page - 1)}
               onClick={(e) => handlePageClick(page - 1, e)}
@@ -98,7 +98,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
         {pageNumbers.map((pageNum, index) => {
           if (pageNum === 'ellipsis') {
             return (
-              <PaginationItem key={`ellipsis-${index}`}>
+              <PaginationItem key={`ellipsis-${index}`} className='hidden md:block'>
                 <PaginationEllipsis />
               </PaginationItem>
             );
@@ -120,7 +120,7 @@ export default function PostPagination({ totalPages }: { totalPages: number }) {
 
         {/* 다음 버튼 */}
         {page < totalPages && (
-          <PaginationItem>
+          <PaginationItem className='hidden md:block'>
             <PaginationNext
               to={createPageUrl(page + 1)}
               onClick={(e) => handlePageClick(page + 1, e)}

--- a/app/components/ui/alert-dialog.tsx
+++ b/app/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "~/lib/utils"
+import { buttonVariants } from "~/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/app/components/ui/popularPostCard.tsx
+++ b/app/components/ui/popularPostCard.tsx
@@ -50,12 +50,12 @@ export default function PopularPostCard({
   return (
     <Link
       to={`/post/${title}`}
-      className='border rounded-lg p-8 flex flex-col gap-4 hover:bg-primary/10 relative'
+      className='border rounded-lg p-4 md:p-8 flex flex-col gap-4 hover:bg-primary/10 relative'
     >
       <div className='absolute bottom-3 right-5 lg:top-5'>
-        <div className='flex flex-row gap-5 items-center h-12 lg:h-16'>
-          <Separator orientation='vertical' className='h-12 lg:h-16' />
-          <div className='text-muted text-3xl lg:text-4xl font-extrabold tracking-wider'>
+        <div className='flex flex-row gap-5 items-center h-8 lg:h-16'>
+          <Separator orientation='vertical' className='h-8 lg:h-16' />
+          <div className='text-muted text-2xl lg:text-4xl font-extrabold tracking-wider'>
             {rank.toString().padStart(2, '0')}
           </div>
         </div>
@@ -72,8 +72,8 @@ export default function PopularPostCard({
         </div>
       </div>
       <div className='flex flex-col gap-2'>
-        <h2 className='text-2xl font-bold'>{title}</h2>
-        <p className='text-muted-foreground text-sm line-clamp-2'>{description}</p>
+        <h2 className='text-xl md:text-2xl font-bold'>{title}</h2>
+        <p className='text-muted-foreground text-xs md:text-sm line-clamp-2'>{description}</p>
       </div>
       <div className='flex flex-row gap-2 items-center'>
         <EyeIcon className='size-4 text-muted-foreground ' />

--- a/app/components/ui/postCard.tsx
+++ b/app/components/ui/postCard.tsx
@@ -17,7 +17,7 @@ function getCategoryStyle(categoryName: CategoryName) {
       backgroundColor: colors.bgColor,
       color: colors.textColor,
     },
-    className: 'rounded-md border px-4 text-sm font-medium',
+    className: 'rounded-md border px-4 text-xs md:text-sm font-medium',
   };
 }
 
@@ -39,16 +39,16 @@ export default function PostCard({
   return (
     <Link
       to={`/post/${title}`}
-      className='border rounded-lg p-8 flex flex-col gap-4 hover:bg-primary/10'
+      className='border rounded-lg p-4 md:p-8 flex flex-col gap-4 hover:bg-primary/10'
     >
       <div className='flex flex-row gap-2 items-center text-muted-foreground'>
         <div {...getCategoryStyle(categoryName as CategoryName)}>{categoryName}</div>
         <DotIcon className='size-5' />
-        <div className='text-muted-foreground text-sm'>{formattedDate}</div>
+        <div className='text-muted-foreground text-xs md:text-sm'>{formattedDate}</div>
       </div>
       <div className='flex flex-col gap-2'>
-        <h2 className='text-2xl font-bold'>{title}</h2>
-        <p className='text-muted-foreground text-sm line-clamp-2'>{description}</p>
+        <h2 className='text-xl md:text-2xl font-bold'>{title}</h2>
+        <p className='text-muted-foreground text-xs md:text-sm line-clamp-2'>{description}</p>
       </div>
       <div className='flex flex-row gap-2 items-center'>
         <ClockIcon className='size-4 text-muted-foreground ' />

--- a/app/components/ui/techBadge.tsx
+++ b/app/components/ui/techBadge.tsx
@@ -1,6 +1,6 @@
 export default function TechBadge({ title }: { title: string }) {
   return (
-    <h4 className='text-xs bg-primary/50 text-primary-foreground border rounded-md px-4 py-2'>
+    <h4 className='text-xs bg-accent/50 text-accent-foreground border rounded-md px-4 py-2'>
       {title}
     </h4>
   );

--- a/app/pages/about.tsx
+++ b/app/pages/about.tsx
@@ -20,6 +20,18 @@ import TechBadge from '~/components/ui/techBadge';
 import { useRef } from 'react';
 import html2canvas from 'html2canvas-pro';
 import { jsPDF } from 'jspdf';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogFooter,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogTrigger,
+  AlertDialogTitle,
+  AlertDialogPortal,
+} from '~/components/ui/alert-dialog';
 
 export const meta: MetaFunction = () => {
   return [
@@ -92,16 +104,30 @@ export default function About() {
             </div>
           </div>
           <div className='flex-col gap-4 mx-4 hidden lg:flex'>
-            <Button
-              variant='outline'
-              size='lg'
-              className='px-6 py-4 text-lg'
-              ref={buttonRef}
-              onClick={handlePrint}
-            >
-              <DownloadIcon className='size-4' />
-              Resume
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild ref={buttonRef}>
+                <Button
+                  variant='outline'
+                  size='lg'
+                  className='px-6 py-4 text-lg flex flex-row items-center gap-2'
+                >
+                  <DownloadIcon className='size-4' />
+                  <span className='text-lg'>Resume</span>
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Download Resume</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Would you like to download the latest version of my resume in PDF format?
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Not Now</AlertDialogCancel>
+                  <AlertDialogAction onClick={handlePrint}>Download</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
             <div className='flex flex-row gap-2'>
               <MapPin className='size-4' />
               <p className='text-muted-foreground text-sm'>Seongnam, South Korea</p>

--- a/app/pages/popularPosts.tsx
+++ b/app/pages/popularPosts.tsx
@@ -28,7 +28,7 @@ export default function PopularPosts({ loaderData }: Route.ComponentProps) {
   return (
     <div className='flex flex-col gap-8 max-w-[1400px] md:ml-20'>
       <div className='flex flex-col gap-4'>
-        <h1 className='text-4xl font-bold'>Popular Posts</h1>
+        <h1 className='text-3xl md:text-4xl font-bold'>Popular Posts</h1>
         <p className='text-muted-foreground'>Most read articles on my blog</p>
       </div>
       <div className='flex flex-col gap-4'>

--- a/app/pages/post.tsx
+++ b/app/pages/post.tsx
@@ -134,15 +134,15 @@ export default function Post({ loaderData }: Route.ComponentProps) {
     <div className='grid grid-cols-1 md:grid-cols-[1fr_280px] xl:grid-cols-[1fr_280px]'>
       <div className='flex flex-col gap-4 mx-3'>
         <HierarchyBar hierarchy={categoryPath} />
-        <h1 className='text-6xl font-bold'>{post.title}</h1>
-        <div className='flex items-center justify-end gap-5'>
+        <h1 className='text-3xl md:text-6xl font-bold'>{post.title}</h1>
+        <div className='flex items-center justify-end gap-5 text-xs md:text-sm'>
           <div className='flex items-center gap-2 text-muted-foreground'>
             <Calendar className='size-4' />
-            <span className='text-sm font-medium'>{formattedDate}</span>
+            <span className='font-medium'>{formattedDate}</span>
           </div>
           <div className='flex items-center gap-2 text-muted-foreground'>
             <Clock className='size-4' />
-            <span className='text-sm font-medium'>{minutesToRead} min read</span>
+            <span className='font-medium'>{minutesToRead} min read</span>
           </div>
         </div>
         {/* 본문 내용 렌더링 */}

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -74,7 +74,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   };
 };
 
-const navLinkVariants = cva('rounded-full border px-4 py-1', {
+const navLinkVariants = cva('rounded-full border px-4 py-1 text-sm md:text-base', {
   variants: {
     isActive: {
       true: 'bg-foreground font-medium text-background',
@@ -93,7 +93,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
     <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] md:ml-20'>
       <div className='flex flex-col gap-8 flex-1'>
         <div className='flex flex-col gap-4'>
-          <h1 className='text-4xl font-bold'>All Posts</h1>
+          <h1 className='text-3xl md:text-4xl font-bold'>All Posts</h1>
           <p className='text-muted-foreground'>
             A collection of 42 articles on programming, technology and life.
           </p>

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -21,27 +21,26 @@ const paramsSchema = z.object({
     .string()
     .optional()
     .default('all')
-    .transform((val) => {
-      if (val === 'all' || !val) return -1;
-      const num = parseInt(val, 10);
-      if (isNaN(num)) {
-        throw new z.ZodError([
-          {
-            code: 'custom',
-            path: ['category'],
-            message: 'Category must be "all" or a valid number',
-          },
-        ]);
-      }
-      return num;
-    }),
+    .refine(
+      (val) => {
+        if (val === 'all' || !val) return true;
+        const num = parseInt(val, 10);
+        return !isNaN(num);
+      },
+      {
+        message: 'Category must be "all" or a valid number',
+      },
+    ),
 });
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { success, data } = paramsSchema.safeParse(params);
   if (!success) {
-    throw new Response('Invalid params', { status: 400 });
+    throw new Response('Invalid category parameter', { status: 404 });
   }
+
+  const categoryValue =
+    data.category === 'all' || !data.category ? -1 : parseInt(data.category, 10);
 
   // 쿼리 파라미터에서 page 읽기 및 검증
   const url = new URL(request.url);
@@ -50,9 +49,14 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 
   // 병렬 실행
   const [totalPages, posts] = await Promise.all([
-    getPostTotalPagesByCategory(client, data.category),
-    getPostsByCategoryAndPage(client, data.category, pageNum),
+    getPostTotalPagesByCategory(client, categoryValue),
+    getPostsByCategoryAndPage(client, categoryValue, pageNum),
   ]);
+
+  // 게시글이 없는 경우 404 에러 발생
+  if (posts.length === 0) {
+    throw new Response('No posts found', { status: 404 });
+  }
 
   // 페이지 범위를 벗어난 경우에만 리다이렉트
   if (pageNum < 1 || (totalPages > 0 && pageNum > totalPages)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "my-react-router-app",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1746,6 +1747,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "blog:upload": "tsx blog/upload-post.ts"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
## 📂 관련 이슈

- closes #55

<br>

## 🔀 PR 개요

> 어떤 작업을 했는지 간단히 설명해주세요.

<br>

## 📝 작업 내용

- about Page의 Tech Stack 뱃지 색 변경
- Posts Page 404 redirect 기능 수정
- header에서 Code Icon을 눌러도 main Page로 이동하도록 구현 및 Header 반응형 수정
- posts, post/popular 반응형 추가
- post 및 markdown rendering 반응형 추가
- Resume Alert 기능 추가

<br>

## 📸 스크린샷
- alert 기능
<img width="794" height="426" alt="image" src="https://github.com/user-attachments/assets/1395d9be-ed77-4778-a51b-8e866f81aa4c" />

- 반응형 추가
<img width="521" height="678" alt="image" src="https://github.com/user-attachments/assets/50b4d661-8755-4071-a139-938dcc3e6d90" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
