### PR TITLE
[Fix] #61 LaTex 블록 Margin 추가

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -171,14 +171,14 @@
   .katex-display-wrapper {
     overflow-x: auto !important;
     max-width: 100% !important;
-    margin: 1rem 0;
+    margin: 2rem 0 !important;
   }
 
-  /* 블록 수식 */
+  /* 블록 수식 (wrapper가 없는 경우를 대비해 직접 margin 추가) */
   .katex-display {
     max-width: 100% !important;
     font-size: 0.75em !important;
-    margin: 0 !important;
+    margin: 2rem 0 !important;
   }
 
   @media (min-width: 640px) {


### PR DESCRIPTION
## 📂 관련 이슈

- closes #61 

<br>

## 🔀 PR 개요

> LaTex 블록 Margin 추가

<br>

## 📝 작업 내용

- LaTex 블록 Margin을 2rem 정도 추가하여 post 가독성 향상

<br>

## 📸 스크린샷

- Before
<img width="1230" height="128" alt="image" src="https://github.com/user-attachments/assets/a23be157-5863-41f2-b323-f05895cac4cb" />


- After
<img width="1241" height="154" alt="image" src="https://github.com/user-attachments/assets/1e8eb36a-620e-4147-a7f4-33aaac9f8060" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과
