### PR TITLE
[Feat&Fix] #65 SiteMap 기능 추가 및 세부 오류 수정

### DIFF
--- a/app/api/posts/posts-api.ts
+++ b/app/api/posts/posts-api.ts
@@ -9,6 +9,14 @@ export const getPosts = async (client: SupabaseClient<Database>) => {
   return data;
 };
 
+export const getPostsCount = async (client: SupabaseClient<Database>) => {
+  const { count, error } = await client.from('posts').select('*', { count: 'exact', head: true });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return count;
+};
+
 export const getPostByTitle = async (client: SupabaseClient<Database>, title: string) => {
   // 대소문자 구분 없이 비교
   const { data, error } = await client.from('posts').select('*').ilike('title', title).single();

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -80,7 +80,7 @@ export default function Header({
 
   return (
     <div className='sticky top-0 z-50 w-full border-b border-border-dark bg-background backdrop-blur'>
-      <div className='h-16 flex justify-between items-center pl-5 md:pl-20'>
+      <div className='h-16 flex justify-between items-center pl-5 xl:pl-20'>
         <div className='flex items-center gap-4'>
           <div className='flex items-center gap-2'>
             <Link to='/' className='flex flex-row items-center gap-2'>

--- a/app/components/layout/leftSideBar.tsx
+++ b/app/components/layout/leftSideBar.tsx
@@ -29,7 +29,7 @@ export default function LeftSidebar({
   const isPostsActive = location.pathname.startsWith('/posts');
 
   return (
-    <div className='hidden md:block'>
+    <div className='hidden xl:block'>
       <div className='flex flex-col gap-10 justify-center'>
         <div className='flex flex-col gap-4'>
           <h1 className='text-sm font-medium text-muted-foreground/50'>DISCOVER</h1>

--- a/app/components/layout/leftSidebarLayout.tsx
+++ b/app/components/layout/leftSidebarLayout.tsx
@@ -8,7 +8,7 @@ export default function LeftSidebarLayout() {
     loaderData: Route.ComponentProps['loaderData'];
   }>();
   return (
-    <div className='mx-auto xl:mx-20 grid grid-cols-1 md:grid-cols-[280px_1fr] xl:grid-cols-[280px_1fr] gap-8 px-6 py-8'>
+    <div className='mx-auto xl:mx-20 grid grid-cols-1 xl:grid-cols-[280px_1fr] gap-8 px-6 py-8'>
       <LeftSidebar
         categoriesTree={loaderData.categoriesTree as FolderItemProps[]}
         events={loaderData.events}

--- a/app/pages/post.tsx
+++ b/app/pages/post.tsx
@@ -131,7 +131,7 @@ export default function Post({ loaderData }: Route.ComponentProps) {
   };
 
   return (
-    <div className='grid grid-cols-1 md:grid-cols-[1fr_280px] xl:grid-cols-[1fr_280px]'>
+    <div className='grid grid-cols-1 xl:grid-cols-[1fr_280px]'>
       <div className='flex flex-col gap-4 mx-3'>
         <HierarchyBar hierarchy={categoryPath} />
         <h1 className='text-3xl md:text-6xl font-bold'>{post.title}</h1>
@@ -158,7 +158,7 @@ export default function Post({ loaderData }: Route.ComponentProps) {
           </Await>
         </Suspense>
       </div>
-      <div className='sticky top-20 hidden md:block self-start'>
+      <div className='sticky top-20 hidden xl:block self-start'>
         <PostSidebar
           activeId={activeId}
           setActiveId={setActiveId}

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -90,7 +90,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
   const { postsWithProcessedExcerpt, totalPages } = loaderData;
 
   return (
-    <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] md:ml-20'>
+    <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] xl:ml-20'>
       <div className='flex flex-col gap-8 flex-1'>
         <div className='flex flex-col gap-4'>
           <h1 className='text-3xl md:text-4xl font-bold'>All Posts</h1>

--- a/app/pages/posts.tsx
+++ b/app/pages/posts.tsx
@@ -4,7 +4,11 @@ import { cva } from 'class-variance-authority';
 import PostCard from '~/components/ui/postCard';
 import PostPagination from '~/components/layout/postPagination';
 import { markdownToText } from '~/lib/markdown-to-text';
-import { getPostsByCategoryAndPage, getPostTotalPagesByCategory } from '~/api/posts/posts-api';
+import {
+  getPostsByCategoryAndPage,
+  getPostsCount,
+  getPostTotalPagesByCategory,
+} from '~/api/posts/posts-api';
 import type { getTopLevelCategories } from '~/api/categories/categories-api';
 import { z } from 'zod';
 import { client } from '~/supa-client';
@@ -48,9 +52,10 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const pageNum = pageParam ? parseInt(pageParam, 10) : 1;
 
   // 병렬 실행
-  const [totalPages, posts] = await Promise.all([
+  const [totalPages, posts, totalPosts] = await Promise.all([
     getPostTotalPagesByCategory(client, categoryValue),
     getPostsByCategoryAndPage(client, categoryValue, pageNum),
+    getPostsCount(client),
   ]);
 
   // 게시글이 없는 경우 404 에러 발생
@@ -71,6 +76,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   return {
     totalPages,
     postsWithProcessedExcerpt,
+    totalPosts,
   };
 };
 
@@ -87,7 +93,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
   const { topLevelCategories } = useOutletContext<{
     topLevelCategories: Awaited<ReturnType<typeof getTopLevelCategories>>;
   }>();
-  const { postsWithProcessedExcerpt, totalPages } = loaderData;
+  const { postsWithProcessedExcerpt, totalPages, totalPosts } = loaderData;
 
   return (
     <div className='flex flex-col min-h-[calc(100vh-4rem)] max-w-[1400px] xl:ml-20'>
@@ -95,7 +101,7 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
         <div className='flex flex-col gap-4'>
           <h1 className='text-3xl md:text-4xl font-bold'>All Posts</h1>
           <p className='text-muted-foreground'>
-            A collection of 42 articles on programming, technology and life.
+            A collection of {totalPosts} articles on programming, technology and life.
           </p>
         </div>
         <div className='flex flex-row flex-wrap gap-2'>

--- a/app/pages/sitemap-xml.tsx
+++ b/app/pages/sitemap-xml.tsx
@@ -1,3 +1,44 @@
-export default function SitemapXml() {
-  return <div>SitemapXml</div>;
+import { getPosts } from '~/api/posts/posts-api';
+import { client } from '~/supa-client';
+
+const BASE_URL = 'https://dongle-portfolio.org/';
+
+function buildUrl(path: string) {
+  return `${BASE_URL}${path}`;
+}
+
+// 필요하다면 Supabase에서 최신 products / jobs / posts 몇 개 가져와서 여기에 섞어줄 수 있음
+export async function loader() {
+  // 1) 정적 페이지들
+  const staticPaths = [
+    '/', // 홈
+    '/posts/all',
+    '/popular',
+    '/about',
+    '/dashboard',
+  ];
+
+  // 2) 게시글 목록
+  const posts = await getPosts(client);
+  const postPaths = posts.map((post) => `/post/${encodeURIComponent(post.title)}`);
+
+  const urls = [...staticPaths, ...postPaths].map((path) => buildUrl(path));
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   ${urls
+     .map(
+       (loc) => `<url>
+         <loc>${loc}</loc>
+       </url>`,
+     )
+     .join('\n')}
+   </urlset>`.trim();
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
 }

--- a/app/pages/sitemap-xml.tsx
+++ b/app/pages/sitemap-xml.tsx
@@ -1,0 +1,3 @@
+export default function SitemapXml() {
+  return <div>SitemapXml</div>;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,6 +1,7 @@
 import { type RouteConfig, index, layout, prefix, route } from '@react-router/dev/routes';
 
 export default [
+  route('/sitemap.xml', 'pages/sitemap-xml.tsx'),
   layout('components/layout/leftSidebarLayout.tsx', [
     index('pages/index.tsx'),
     ...prefix('posts', [route('/:category', 'pages/posts.tsx')]),

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://dongle-portfolio.org/sitemap.xml


### PR DESCRIPTION
## 📂 관련 이슈

- closes #65 

<br>

## 🔀 PR 개요

> SiteMap 기능 추가 및 세부 오류 수정

<br>

## 📝 작업 내용

- robots.txt 파일 추가
- sitemap-xml 경로 추가
- sitemap-xml 구현
- md 반응형 레이아웃 수정
- All posts에 전체 Post 수가 Text로 고정되어 있던 오류 수정)

<br>

## 📸 스크린샷
- md 반응형 레이아웃 수정전
<img width="1179" height="968" alt="image" src="https://github.com/user-attachments/assets/cb29d6d0-2858-470f-90e8-87c5970a7386" />

- md 반응형 레이아웃 수정후
<img width="1181" height="968" alt="image" src="https://github.com/user-attachments/assets/4a159e17-e285-4e60-a4f4-47cf14e54ae9" />

- All post 개수 수정
<img width="515" height="85" alt="image" src="https://github.com/user-attachments/assets/a3496ed0-fd32-4e9f-86e5-a49d0f6a6474" />
<br>


## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
